### PR TITLE
allow simple arrays in schema

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,11 @@
   function deepPick(object, json){
     if(_.isArray(json) && _.isArray(object)){
       return _.map(object, function(item){
-        return deepPick(item, json[0]);
+        if(_.isObject(item)) {
+          return deepPick(item, json[0]);
+        } else {
+          return item;
+        }
       });
     }
     object = _.pick(object, _.keys(json));

--- a/test.js
+++ b/test.js
@@ -24,6 +24,7 @@ var input = {
 var schema = {
   one: true,
   three: true,
+  four: [true],
   five: {
     alpha: true,
     teta: {
@@ -37,10 +38,9 @@ var schema = {
   ]
 };
 
-
 console.assert(
   JSON.stringify(_.deepPick(input, schema)) ===
-  '{"one":1,"three":"Three","five":{"alpha":1,"teta":{"beh":2}}}'
+  '{"one":1,"three":"Three","four":[1,2,3,4],"five":{"alpha":1,"teta":{"beh":2}}}'
 );
 
 


### PR DESCRIPTION
Consider simple array like:

var input = { a: [1,2, 3] };

var schema = { a: [true] };

_.deepPick(input, schema) // { a : {} }
